### PR TITLE
Raise key error if key not in db

### DIFF
--- a/persistentdict/dict_in_redis.py
+++ b/persistentdict/dict_in_redis.py
@@ -88,7 +88,7 @@ class PersistentDict:
         """
         value = self.db.hget(self.hash, key)
         if value is None:
-            return None
+            raise KeyError(f"Key '{key}' does not exist.")
         return json.loads(value)
 
     def __len__(self):

--- a/tests/test_dict_in_redis.py
+++ b/tests/test_dict_in_redis.py
@@ -39,3 +39,7 @@ class TestPersistentDict:
         assert db.keys() == dictionary.keys()
         db.clear()
         assert len(db) == 0
+
+    def test_should_raise_key_error_if_key_is_not_in_db(self, db, dictionary):
+        with raises(KeyError, match="Key 'unknown' does not exist."):
+            db['unknown']

--- a/tests/test_dict_in_redis.py
+++ b/tests/test_dict_in_redis.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from pytest import fixture
+from pytest import fixture, raises
 
 from persistentdict.dict_in_redis import PersistentDict
 


### PR DESCRIPTION
Fixes #4 

Test:

```
python3 -m pytest --color=yes --verbose --showlocals
========================================================================== test session starts ==========================================================================
platform linux -- Python 3.6.8, pytest-5.2.1, py-1.8.0, pluggy-0.13.0 -- /tmp/persistentdict-fork/venv/bin/python3
cachedir: .pytest_cache
rootdir: /tmp/persistentdict-fork
collected 3 items                                                                                                                                                       

tests/test_dict_in_redis.py::TestPersistentDict::test_one_by_one PASSED                                                                                           [ 33%]
tests/test_dict_in_redis.py::TestPersistentDict::test_more_keys PASSED                                                                                            [ 66%]
tests/test_dict_in_redis.py::TestPersistentDict::test_should_raise_key_error_if_key_is_not_in_db PASSED                                                           [100%]

=========================================================================== 3 passed in 0.06s ===========================================================================

```