### PR TITLE
Add get method

### DIFF
--- a/persistentdict/dict_in_redis.py
+++ b/persistentdict/dict_in_redis.py
@@ -140,6 +140,21 @@ class PersistentDict:
         for key in self.keys():
             self.__delitem__(key)
 
+    def get(self, key, default=None):
+        """Get info to key or default, if key not present.
+
+        Usage:
+        xyz = PersistentDict().get(key, default)
+
+        :param key: can be int or string
+        :param default: can be anything, default is None
+        :return: value assigned to the key or default if key not in db
+        """
+        value = self.db.hget(self.hash, key)
+        if value is None:
+            return default
+        return json.loads(value)
+
     def get_all(self):
         """
         Return whole dictionary

--- a/tests/test_dict_in_redis.py
+++ b/tests/test_dict_in_redis.py
@@ -39,3 +39,16 @@ class TestPersistentDict:
         assert db.keys() == dictionary.keys()
         db.clear()
         assert len(db) == 0
+    
+    def test_should_get_none_if_no_default(self, db, dictionary):
+        actual = db.get('unknown')
+        assert actual is None
+    
+    def test_should_get_default_if_no_key(self, db, dictionary):
+        actual = db.get('unknown', 'default')
+        assert actual == 'default'
+    
+    def test_should_get_value(self, db, dictionary):
+        db['key'] = 'value'
+        actual = db.get('key')
+        assert actual == 'value'


### PR DESCRIPTION
Fixes #6 .

Pytest:

```
python3 -m pytest --color=yes --verbose --showlocals
========================================================================== test session starts ==========================================================================
platform linux -- Python 3.6.8, pytest-5.2.1, py-1.8.0, pluggy-0.13.0 -- /tmp/persistentdict/venv/bin/python3
cachedir: .pytest_cache
rootdir: /tmp/persistentdict
collected 6 items                                                                                                                                                       

tests/test_dict_in_redis.py::TestPersistentDict::test_one_by_one PASSED                                                                                           [ 16%]
tests/test_dict_in_redis.py::TestPersistentDict::test_more_keys PASSED                                                                                            [ 33%]
tests/test_dict_in_redis.py::TestPersistentDict::test_should_raise_key_error_if_key_is_not_in_db PASSED                                                           [ 50%]
tests/test_dict_in_redis.py::TestPersistentDict::test_should_get_none_if_no_default PASSED                                                                        [ 66%]
tests/test_dict_in_redis.py::TestPersistentDict::test_should_get_default_if_no_key PASSED                                                                         [ 83%]
tests/test_dict_in_redis.py::TestPersistentDict::test_should_get_value PASSED                                                                                     [100%]

=========================================================================== 6 passed in 0.09s ===========================================================================
```